### PR TITLE
Removed GUID from streams/schemas that have a GUID already

### DIFF
--- a/tap_marketman/schemas/inventory_count.json
+++ b/tap_marketman/schemas/inventory_count.json
@@ -21,7 +21,6 @@
                     "TotalValue": { "type": ["number", "null"] }
                 }
             }
-        },
-        "GUID": { "type": ["string"] }
+        }
     }
 }

--- a/tap_marketman/schemas/order_by_sent_date.json
+++ b/tap_marketman/schemas/order_by_sent_date.json
@@ -36,7 +36,6 @@
                     "PackPerCase": { "type": ["integer", "null"] }
                 }
             }
-        },
-        "GUID": { "type": ["string"] }
+        }
     }
 }

--- a/tap_marketman/schemas/transfer.json
+++ b/tap_marketman/schemas/transfer.json
@@ -26,7 +26,6 @@
                     "UOMName": { "type": ["string", "null"] }
                 }
             }
-        },
-        "GUID": { "type": ["string"] }
+        }
     }
 }

--- a/tap_marketman/schemas/waste_event.json
+++ b/tap_marketman/schemas/waste_event.json
@@ -23,7 +23,6 @@
                 "UOMName": { "type": ["string", "null"] }
                 }
             }
-        },
-        "GUID": { "type": ["string"] }
+        }
     }
 }

--- a/tap_marketman/streams.py
+++ b/tap_marketman/streams.py
@@ -107,7 +107,6 @@ class InventoryCount(FullTableStream):
                                                     end_time=end_time)
         inventory_counts = response['InventoryCounts']
         for inventory_count in inventory_counts:
-            inventory_count['GUID'] = current_guid
             yield inventory_count
 
 
@@ -134,7 +133,6 @@ class Transfer(FullTableStream):
                                              end_time=end_time)
         transfers = response['Transfers']
         for transfer in transfers:
-            transfer['GUID'] = current_guid
             yield transfer
 
 
@@ -161,7 +159,6 @@ class WasteEvent(FullTableStream):
                                                 end_time=end_time)
         waste_events = response['WasteEvents']
         for waste_event in waste_events:
-            waste_event['GUID'] = current_guid
             yield waste_event
 
 
@@ -194,7 +191,6 @@ class OrderBySentDate(FullTableStream):
             end_time = start_time + timedelta(days=14)
             orders = response['Orders']
             for order in orders:
-                order['GUID'] = current_guid
                 yield order
 
             singer.write_bookmark(


### PR DESCRIPTION
# Description :: User Story

Modify schemas and streams to remove additional GUID fields from endpoints that already produced a GUID. 

Affected Streams - `Inventory Count`, `Transfers`, `Waste Events`, `Order by Sent Date`.

## Type of Change

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
